### PR TITLE
Fix inconsistent single and double quotes

### DIFF
--- a/spec/lib/sidekiq/matchers/have_queued_job_at_spec.rb
+++ b/spec/lib/sidekiq/matchers/have_queued_job_at_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe :have_queued_job_at do
   subject(:worker) { Worker }

--- a/spec/lib/sidekiq/matchers/have_queued_job_spec.rb
+++ b/spec/lib/sidekiq/matchers/have_queued_job_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe :have_queued_job do
   subject(:worker) { Worker }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
-require 'sidekiq'
-require 'sidekiq/testing'
-require 'sidekiq/matchers'
+require "sidekiq"
+require "sidekiq/testing"
+require "sidekiq/matchers"
 
 Dir["./spec/support/**/*.rb"].each { |f| require f }
 
@@ -13,5 +13,5 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = 'random'
+  config.order = "random"
 end


### PR DESCRIPTION
It seems like single quotes and double quotes are being used
interchangably in the code. I could not find any underlying pattern
behind the use of single quotes or double quotes so I switched
everything over to double quotes. This provides the code base with a
higher degree of consistency.
